### PR TITLE
Rewrite event handling and add support for mouse events

### DIFF
--- a/canvas.fsproj
+++ b/canvas.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>DIKU.Canvas</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.3</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Authors>Martin Elsman, Ken Friis Larsen, Mads Obitsø, Jon Sporring</Authors>
     <Company>DIKU</Company>

--- a/examples/color_boxes.fsx
+++ b/examples/color_boxes.fsx
@@ -1,4 +1,5 @@
-#r "nuget:DIKU.Canvas"
+#i "nuget:/home/mads/Documents/diku/instruktor/pop2022/imgUtilTesting/diku-canvas/bin/Debug"
+#r "nuget:DIKU.Canvas, 1.0.3"
 
 open Canvas
 


### PR DESCRIPTION
*NB: Feel very free to reject this or suggest changes. The new event handling feels very hacky, but trust me - I tried doing it "the right way" for long enough to give up.*


Currently support for keydown, keyup, mousedown, mouseup and mousemotion events.

The new implementation is not pretty, but trust me, it works. SDL_Event is a union of C-structs. dotnet is not keen on letting us write a "union struct" that does not necessarily have the same alignment of fields in each possible member-struct.

By "chunking through it" and manually converting to records all of this is avoided.

Implements #22 
