### PR TITLE
Add support for mouse events

### DIFF
--- a/SDL.fs
+++ b/SDL.fs
@@ -129,9 +129,9 @@ type Event =
     | Quit
     | KeyDown of SDL_KeyboardEvent
     | KeyUp of SDL_KeyboardEvent
+    | MouseMotion of SDL_MouseMotionEvent
     | MouseButtonDown of SDL_MouseButtonEvent
     | MouseButtonUp of SDL_MouseButtonEvent
-    | MouseMotion of SDL_MouseMotionEvent
     | User of SDL_UserEvent
     | Raw of SDL_Event
 
@@ -140,10 +140,10 @@ let convertEvent (event: SDL_Event) =
         | c when c = SDL_QUIT -> Quit
         | c when c = SDL_KEYDOWN -> event.key |> KeyDown
         | c when c = SDL_KEYUP -> event.key |> KeyUp
-        | c when c >= SDL_USEREVENT -> event.user |> User
+        | c when c = SDL_MOUSEMOTION -> event.motion |> MouseMotion
         | c when c = SDL_MOUSEBUTTONDOWN -> event.button |> MouseButtonDown
         | c when c = SDL_MOUSEBUTTONUP -> event.button |> MouseButtonUp
-        | c when c = SDL_MOUSEMOTION -> event.motion |> MouseMotion
+        | c when c >= SDL_USEREVENT -> event.user |> User
         | _ -> event |> Raw
 
 type SDL_RendererFlags =

--- a/SDL.fs
+++ b/SDL.fs
@@ -28,6 +28,9 @@ let SDL_PIXELFORMAT_RGBA32 = if BitConverter.IsLittleEndian
                              else SDL_PIXELFORMAT_RGBA8888
 let SDL_KEYDOWN = 0x300u
 let SDL_KEYUP = 0x301u
+let SDL_MOUSEMOTION = 0x400u
+let SDL_MOUSEBUTTONDOWN = 0x401u
+let SDL_MOUSEBUTTONUP = 0x402u
 // Define keycodes for SDL
 // https://wiki.libsdl.org/SDLKeycodeLookup
 let SDLK_ESCAPE = 27u
@@ -76,6 +79,35 @@ type SDL_UserEvent=
         val data2: IntPtr
     end
 
+[<StructLayout(LayoutKind.Sequential)>]
+type SDL_MouseButtonEvent=
+    struct
+        val ``type``: uint32
+        val timestamp: uint32
+        val windowID: uint32
+        val which: uint32
+        val button: byte
+        val state: byte
+        val clicks: byte
+        val padding1: byte
+        val x: int32
+        val y: int32
+    end
+
+[<StructLayout(LayoutKind.Sequential)>]
+type SDL_MouseMotionEvent=
+    struct
+        val ``type``: uint32
+        val timestamp: uint32
+        val windowID: uint32
+        val which: uint32
+        val state: uint32
+        val x: int32
+        val y: int32
+        val xrel: int32
+        val yrel: int32
+    end
+
 // Trick to encode a C union type
 #nowarn "9"
 [<StructLayout(LayoutKind.Explicit, Size=56)>]
@@ -87,12 +119,19 @@ type SDL_Event =
         val key: SDL_KeyboardEvent
         [<FieldOffset(0)>]
         val user: SDL_UserEvent
+        [<FieldOffset(0)>]
+        val button: SDL_MouseButtonEvent
+        [<FieldOffset(0)>]
+        val motion: SDL_MouseMotionEvent
     end
 
 type Event =
     | Quit
     | KeyDown of SDL_KeyboardEvent
     | KeyUp of SDL_KeyboardEvent
+    | MouseButtonDown of SDL_MouseButtonEvent
+    | MouseButtonUp of SDL_MouseButtonEvent
+    | MouseMotion of SDL_MouseMotionEvent
     | User of SDL_UserEvent
     | Raw of SDL_Event
 
@@ -102,6 +141,9 @@ let convertEvent (event: SDL_Event) =
         | c when c = SDL_KEYDOWN -> event.key |> KeyDown
         | c when c = SDL_KEYUP -> event.key |> KeyUp
         | c when c >= SDL_USEREVENT -> event.user |> User
+        | c when c = SDL_MOUSEBUTTONDOWN -> event.button |> MouseButtonDown
+        | c when c = SDL_MOUSEBUTTONUP -> event.button |> MouseButtonUp
+        | c when c = SDL_MOUSEMOTION -> event.motion |> MouseMotion
         | _ -> event |> Raw
 
 type SDL_RendererFlags =

--- a/canvas.fs
+++ b/canvas.fs
@@ -130,9 +130,15 @@ let getKey (k:key) : ImgUtilKey =
         | _ when kval = SDL.SDLK_RIGHT -> RightArrow
         | _ -> Unknown
 
+
+
 type event =
     | KeyDown of key
     | TimerTick
+    | MouseButtonDown of int * int // x,y
+    | MouseButtonUp of int * int // x,y
+    | MouseMotion of int * int * int * int // x,y, relx, rely
+
 
 let runAppWithTimer (t:string) (w:int) (h:int) (interval:int option)
            (draw: int -> int -> 's -> canvas)
@@ -206,6 +212,27 @@ let runAppWithTimer (t:string) (w:int) (h:int) (interval:int option)
                         match react (!state) TimerTick with
                             | Some s -> (state := s; true)
                             | None   -> false
+                    drawLoop redraw
+                | SDL.MouseButtonDown mouseButtonEvent ->
+                    let mouseEvent = (mouseButtonEvent.x,mouseButtonEvent.y) |> MouseButtonDown
+                    let redraw =
+                        match react (!state) mouseEvent with
+                            | Some s -> (state := s; true)
+                            | None -> false
+                    drawLoop redraw
+                | SDL.MouseButtonUp mouseButtonEvent ->
+                    let mouseEvent = (mouseButtonEvent.x,mouseButtonEvent.y) |> MouseButtonUp
+                    let redraw =
+                        match react (!state) mouseEvent with
+                            | Some s -> (state := s; true)
+                            | None -> false
+                    drawLoop redraw
+                | SDL.MouseMotion mouseMotion ->
+                    let mouseEvent = (mouseMotion.x,mouseMotion.y,mouseMotion.xrel, mouseMotion.yrel) |> MouseMotion
+                    let redraw =
+                        match react (!state) mouseEvent with
+                            | Some s -> (state := s; true)
+                            | None -> false
                     drawLoop redraw
                 | _ ->
                     drawLoop false

--- a/canvas.fsi
+++ b/canvas.fsi
@@ -76,7 +76,9 @@ val runApp    : string -> int -> int
 type event =
     | KeyDown of key
     | TimerTick
-
+    | MouseButtonDown of int * int // x,y
+    | MouseButtonUp of int * int // x,y
+    | MouseMotion of int * int * int * int // x,y, relx, rely
 
 /// Start an app that can listen to key-events and timer-events
 val runAppWithTimer: string -> int -> int -> int option

--- a/examples/mouseTest.fsx
+++ b/examples/mouseTest.fsx
@@ -1,0 +1,32 @@
+#i "nuget:/home/mads/Documents/diku/instruktor/pop2022/imgUtilTesting/diku-canvas/bin/Debug"
+#r "nuget:DIKU.Canvas, 1.0.2-alpha1"
+
+open Canvas
+
+type state = Canvas.color
+
+let getColClick = function
+    | (x,y) -> fromRgb (x , y, 0)
+
+let getColRelease = function
+    | (x,y) -> fromRgb (0, x, y)
+    
+let draw w h (s:state) =
+  let bm = Canvas.create w h
+  setFillBox bm s (0,0) (w,h)
+  bm
+
+let react (s:state) (ev:Canvas.event) : state option =
+    match ev with
+        | MouseButtonDown (x,y) ->
+            printfn "Clicked at x: %d, y: %d" x y
+            getColClick (x,y) |> Some
+        | MouseButtonUp (x,y) ->
+            printfn "Released at x: %d, y: %d" x y
+            getColRelease (x,y) |> Some
+        | MouseMotion (x,y,xrel,yrel) ->
+            printfn "moved! x: %d, y: %d, xrel: %d, yrel: %d" x y xrel yrel
+            None
+        // Ignore all non-mouse events
+        | _ -> None
+do runAppWithTimer "MouseEvent Test" 600 600 None draw react (black)


### PR DESCRIPTION
Currently does not differentiate between buttons clicked or released, i.e. left-middle-right clicks are all the same.

